### PR TITLE
Assorted fixes for a handful of white backgrounds

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1664,8 +1664,8 @@ ul.comparison-list > li em {
 
 /** Filters */
 .filter-bar {
-  background-color: var(--s-background);
-  border-bottom: 1px solid var(--white-4);
+  background-color: var(--white-1);
+  border-color: var(--white-1);
 }
 
 .filter-item {
@@ -1697,7 +1697,7 @@ ul.comparison-list > li em {
 
 .user-profile-sticky-bar:after {
   background-color: var(--white-1);
-  border-bottom: 1px solid var(--white-3);
+  border-color: var(--white-3);
   height: 54px;
 }
 
@@ -1825,7 +1825,7 @@ ul.comparison-list > li em {
 
 /** Insights graphs */
 .graph-canvas .axis .tick text {
-  fill: var(--black-1)  
+  fill: var(--black-1);
 }
 
 .graph-canvas .axis line {
@@ -1853,7 +1853,7 @@ ul.comparison-list > li em {
 }
 
 .capped-card-content {
-  background: var(--white-1);
+  background-color: var(--white-2);
 }
 
 /** File finder */

--- a/theme.css
+++ b/theme.css
@@ -1698,6 +1698,7 @@ ul.comparison-list > li em {
 .user-profile-sticky-bar:after {
   background-color: var(--white-1);
   border-bottom: 1px solid var(--white-3);
+  height: 54px;
 }
 
 .UnderlineNav {

--- a/theme.css
+++ b/theme.css
@@ -1829,7 +1829,7 @@ ul.comparison-list > li em {
 }
 
 .graph-canvas .axis line {
-  stroke: var(--white-5);
+  stroke: var(--white-3);
 }
 
 .tint-box {

--- a/theme.css
+++ b/theme.css
@@ -1663,6 +1663,11 @@ ul.comparison-list > li em {
 }
 
 /** Filters */
+.filter-bar {
+  background-color: var(--s-background);
+  border-bottom: 1px solid var(--white-4);
+}
+
 .filter-item {
   color: var(--black-3);
 }
@@ -1688,6 +1693,11 @@ ul.comparison-list > li em {
 .user-profile-nav {
   background-color: var(--white-1);
   border-color: var(--white-4);
+}
+
+.user-profile-sticky-bar:after {
+  background-color: var(--white-1);
+  border-bottom: 1px solid var(--white-3);
 }
 
 .UnderlineNav {
@@ -1814,7 +1824,7 @@ ul.comparison-list > li em {
 
 /** Insights graphs */
 .graph-canvas .axis .tick text {
-  fill: var(--black-1)
+  fill: var(--black-1)  
 }
 
 .graph-canvas .axis line {
@@ -1839,6 +1849,10 @@ ul.comparison-list > li em {
 
 .traffic-graph-stats {
   border-color: var(--white-6);
+}
+
+.capped-card-content {
+  background: var(--white-1);
 }
 
 /** File finder */


### PR DESCRIPTION
This fixes a few areas where I noticed white backgrounds showing through. Some examples are below:

- https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags

<details><summary>Before and after</summary>
<img width="1043" alt="Screen Shot 2020-05-21 at 12 00 26 AM" src="https://user-images.githubusercontent.com/456942/82532932-249ba080-9af7-11ea-8180-5d6b44bb767b.png">
<hr>
<img width="1021" alt="Screen Shot 2020-05-21 at 12 02 27 AM" src="https://user-images.githubusercontent.com/456942/82533324-e2269380-9af7-11ea-9dd6-139822766c68.png">
</details>

- https://github.com/parasyte?tab=repositories (scroll down a bit to make the floating header appear)

<details><summary>Before and after</summary>
<img width="1349" alt="Screen Shot 2020-05-21 at 12 00 51 AM" src="https://user-images.githubusercontent.com/456942/82532945-2cf3db80-9af7-11ea-9913-78730cf507f4.png">
<hr>
<img width="1288" alt="Screen Shot 2020-05-21 at 12 07 29 AM" src="https://user-images.githubusercontent.com/456942/82533341-ebaffb80-9af7-11ea-9f9b-b0be915b9f94.png">
</details>

- https://github.com/mskelton/github-one-dark-theme/graphs/contributors

<details><summary>Before and after</summary>
<img width="1008" alt="Screen Shot 2020-05-21 at 12 01 58 AM" src="https://user-images.githubusercontent.com/456942/82532956-367d4380-9af7-11ea-901a-dffe286c8e4f.png">
<hr>
<img width="1011" alt="Screen Shot 2020-05-21 at 12 07 40 AM" src="https://user-images.githubusercontent.com/456942/82533013-501e8b00-9af7-11ea-83fa-825b601fa78a.png">
</details>