### PR TITLE
Fix code selection background color

### DIFF
--- a/theme.user.css
+++ b/theme.user.css
@@ -1427,6 +1427,11 @@ the consistent color palette. */
     color: var(--s-ivory);
   }
 
+  .blob-code-inner.highlighted,
+  .blob-code-inner .highlighted {
+    background-color: var(--blue-3);
+  }
+
   .blob-num:hover {
     color: var(--black-1);
   }


### PR DESCRIPTION
When selecting lines in a diff or file, the background color is yellow. This makes it dark blue, which is much nicer.